### PR TITLE
Fix linking statically with OpenSSL 1.0.x

### DIFF
--- a/cscrypt/mdc2.c
+++ b/cscrypt/mdc2.c
@@ -32,7 +32,7 @@
         }
 
 //OPENSSL_GLOBAL const DES_LONG DES_SPtrans[8][64] =
-const DES_LONG DES_SPtrans[8][64] =
+const DES_LONG DES_SPtransOSEMU[8][64] =
 {
 	{
 		/* nibble 0 */
@@ -199,14 +199,14 @@ const DES_LONG DES_SPtrans[8][64] =
         LOAD_DATA_tmp(R,S,u,t,E0,E1); \
         t=ROTATE(t,4); \
         LL^= \
-            DES_SPtrans[0][(u>> 2L)&0x3f]^ \
-            DES_SPtrans[2][(u>>10L)&0x3f]^ \
-            DES_SPtrans[4][(u>>18L)&0x3f]^ \
-            DES_SPtrans[6][(u>>26L)&0x3f]^ \
-            DES_SPtrans[1][(t>> 2L)&0x3f]^ \
-            DES_SPtrans[3][(t>>10L)&0x3f]^ \
-            DES_SPtrans[5][(t>>18L)&0x3f]^ \
-            DES_SPtrans[7][(t>>26L)&0x3f]; }
+            DES_SPtransOSEMU[0][(u>> 2L)&0x3f]^ \
+            DES_SPtransOSEMU[2][(u>>10L)&0x3f]^ \
+            DES_SPtransOSEMU[4][(u>>18L)&0x3f]^ \
+            DES_SPtransOSEMU[6][(u>>26L)&0x3f]^ \
+            DES_SPtransOSEMU[1][(t>> 2L)&0x3f]^ \
+            DES_SPtransOSEMU[3][(t>>10L)&0x3f]^ \
+            DES_SPtransOSEMU[5][(t>>18L)&0x3f]^ \
+            DES_SPtransOSEMU[7][(t>>26L)&0x3f]; }
 
 #define IP(l,r) \
         { \
@@ -497,7 +497,7 @@ void DES_set_odd_parity(DES_cblock *key)
 }
 
 
-void DES_encrypt1(DES_LONG *data, DES_key_schedule *ks, int enc)
+void DES_encrypt1OSEMU(DES_LONG *data, DES_key_schedule *ks, int enc)
 {
 	register DES_LONG l, r, t, u;
 	register DES_LONG *s;
@@ -641,11 +641,11 @@ static void mdc2_body(MDC2_CTX *c, const unsigned char *in, size_t len)
 
 		DES_set_odd_parity(&c->h);
 		DES_set_key_unchecked(&c->h, &k);
-		DES_encrypt1(d, &k, 1);
+		DES_encrypt1OSEMU(d, &k, 1);
 
 		DES_set_odd_parity(&c->hh);
 		DES_set_key_unchecked(&c->hh, &k);
-		DES_encrypt1(dd, &k, 1);
+		DES_encrypt1OSEMU(dd, &k, 1);
 
 		ttin0 = tin0 ^ dd[0];
 		ttin1 = tin1 ^ dd[1];


### PR DESCRIPTION
When  building oscam-patched with libssl.a and libcrypto.a linked in statically, the build will fail with:

multiple definition of `DES_encrypt1'
multiple definition of `DES_SPtrans'

This is because those functions are already provided by OpenSSL.
Now for some reason you guys decided to not use the OpenSSL versions of these functions and just re-define them.

So let's rename them so that we can still link statically.

I've tested multiple builds across multiple platforms (x86, mips, sh4) both with static and dynamically linked libssl/libcrypto.
All working OK!